### PR TITLE
Try out struct based generator encapsulating Rng and Config.

### DIFF
--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 mod people;
 mod strings;
 
-pub struct NexmarkGenerator<R: Rng + ?Sized> {
+pub struct NexmarkGenerator<R: Rng> {
     config: Config,
     rng: R,
 }

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Based on the equivalent [Nexmark Flink generator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator).
 
+use crate::config::Config;
 use rand::Rng;
 
 mod people;
 mod strings;
 
 pub struct NexmarkGenerator<R: Rng + ?Sized> {
+    config: Config,
     rng: R,
 }

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -2,5 +2,11 @@
 //!
 //! Based on the equivalent [Nexmark Flink generator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator).
 
+use rand::Rng;
+
 mod people;
 mod strings;
+
+pub struct NexmarkGenerator<R: Rng + ?Sized> {
+    rng: R,
+}

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -6,6 +6,8 @@ use super::NexmarkGenerator;
 use crate::config;
 use crate::model::{DateTime, Id, Person};
 use rand::{seq::SliceRandom, Rng};
+use std::cmp::min;
+use std::time::Duration;
 
 // Keep the number of states small so that the example queries will find
 // results even with a small batch of events.
@@ -49,7 +51,7 @@ impl<R: Rng + ?Sized> NexmarkGenerator<R> {
             credit_card: self.next_credit_card(),
             city: self.next_us_city(),
             state: self.next_us_state(),
-            date_time: DateTime::UNIX_EPOCH + std::time::Duration::from_millis(timestamp),
+            date_time: DateTime::UNIX_EPOCH + Duration::from_millis(timestamp),
             extra: String::new(),
         }
     }
@@ -67,7 +69,7 @@ impl<R: Rng + ?Sized> NexmarkGenerator<R> {
     /// FIRST_PERSON_ID offset, and should really be "offset 0".
     pub fn next_base0_person_id(&mut self, event_id: Id) -> Id {
         let num_people = self.last_base0_person_id(event_id) + 1;
-        let active_people = std::cmp::min(num_people, config::NUM_ACTIVE_PEOPLE);
+        let active_people = min(num_people, config::NUM_ACTIVE_PEOPLE);
         let n = self
             .rng
             .gen_range(0..(active_people + config::PERSON_ID_LEAD));
@@ -157,8 +159,7 @@ mod tests {
                 credit_card: "0000 0000 0000 0000".into(),
                 city: "Phoenix".into(),
                 state: "AZ".into(),
-                date_time: DateTime::UNIX_EPOCH
-                    + std::time::Duration::from_millis(1_000_000_000_000),
+                date_time: DateTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
                 extra: String::new(),
             }
         );

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -34,7 +34,7 @@ const LAST_NAMES: &[&str] = &[
     "Shultz", "Abrams", "Spencer", "White", "Bartels", "Walton", "Smith", "Jones", "Noris",
 ];
 
-impl<R: Rng + ?Sized> NexmarkGenerator<R> {
+impl<R: Rng> NexmarkGenerator<R> {
     // Generate and return a random person with next available id.
     pub fn next_person(&mut self, next_event_id: Id, timestamp: u64) -> Person {
         // TODO(absoludity): Figure out the purpose of the extra field - appears to be

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -2,7 +2,7 @@
 //!
 //! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/PersonGenerator.java).
 
-use super::strings::next_string;
+use super::NexmarkGenerator;
 use crate::config;
 use crate::model::{DateTime, Id, Person};
 use rand::{seq::SliceRandom, Rng};
@@ -32,102 +32,102 @@ const LAST_NAMES: &[&str] = &[
     "Shultz", "Abrams", "Spencer", "White", "Bartels", "Walton", "Smith", "Jones", "Noris",
 ];
 
-// Generate and return a random person with next available id.
-pub fn next_person<R: Rng + ?Sized>(
-    conf: &config::Config,
-    next_event_id: Id,
-    rng: &mut R,
-    timestamp: u64,
-) -> Person {
-    // TODO(absoludity): Figure out the purpose of the extra field - appears to be
-    // aiming to adjust the number of bytes for the record to be an average, which will
-    // need slightly different handling in Rust.
-    // int currentSize =
-    //     8 + name.length() + email.length() + creditCard.length() + city.length() + state.length();
-    // String extra = nextExtra(random, currentSize, config.getAvgPersonByteSize());
+impl<R: Rng + ?Sized> NexmarkGenerator<R> {
+    // Generate and return a random person with next available id.
+    pub fn next_person(
+        &mut self,
+        conf: &config::Config,
+        next_event_id: Id,
+        timestamp: u64,
+    ) -> Person {
+        // TODO(absoludity): Figure out the purpose of the extra field - appears to be
+        // aiming to adjust the number of bytes for the record to be an average, which will
+        // need slightly different handling in Rust.
+        // int currentSize =
+        //     8 + name.length() + email.length() + creditCard.length() + city.length() + state.length();
+        // String extra = nextExtra(random, currentSize, config.getAvgPersonByteSize());
 
-    Person {
-        id: last_base0_person_id(conf, next_event_id) + config::FIRST_PERSON_ID,
-        name: next_person_name(rng),
-        email_address: next_email(rng),
-        credit_card: next_credit_card(rng),
-        city: next_us_city(rng),
-        state: next_us_state(rng),
-        date_time: DateTime::UNIX_EPOCH + std::time::Duration::from_millis(timestamp),
-        extra: String::new(),
+        Person {
+            id: self.last_base0_person_id(conf, next_event_id) + config::FIRST_PERSON_ID,
+            name: self.next_person_name(),
+            email_address: self.next_email(),
+            credit_card: self.next_credit_card(),
+            city: self.next_us_city(),
+            state: self.next_us_state(),
+            date_time: DateTime::UNIX_EPOCH + std::time::Duration::from_millis(timestamp),
+            extra: String::new(),
+        }
     }
-}
 
-/// Return a random person id (base 0).
-///
-/// Choose a random person from any of the 'active' people, plus a few 'leads'.
-/// By limiting to 'active' we ensure the density of bids or auctions per person
-/// does not decrease over time for long running jobs.  By choosing a person id
-/// ahead of the last valid person id we will make newPerson and newAuction
-/// events appear to have been swapped in time.
-///
-/// NOTE: The above is the original comment from the Java implementation. The
-/// "base 0" is referring to the fact that the returned Id is not including the
-/// FIRST_PERSON_ID offset, and should really be "offset 0".
-pub fn next_base0_person_id<R: Rng + ?Sized>(
-    conf: &config::Config,
-    event_id: Id,
-    rng: &mut R,
-) -> Id {
-    let num_people = last_base0_person_id(conf, event_id) + 1;
-    let active_people = std::cmp::min(num_people, config::NUM_ACTIVE_PEOPLE);
-    let n = rng.gen_range(0..(active_people + config::PERSON_ID_LEAD));
-    num_people - active_people + n
-}
-
-/// Return the last valid person id (ignoring FIRST_PERSON_ID). Will be the
-/// current person id if due to generate a person.
-pub fn last_base0_person_id(conf: &config::Config, event_id: Id) -> Id {
-    let epoch = event_id / conf.total_proportion();
-    let mut offset = event_id % conf.total_proportion();
-
-    if offset >= conf.person_proportion {
-        // About to generate an auction or bid.
-        // Go back to the last person generated in this epoch.
-        offset = conf.person_proportion - 1;
+    /// Return a random person id (base 0).
+    ///
+    /// Choose a random person from any of the 'active' people, plus a few 'leads'.
+    /// By limiting to 'active' we ensure the density of bids or auctions per person
+    /// does not decrease over time for long running jobs.  By choosing a person id
+    /// ahead of the last valid person id we will make newPerson and newAuction
+    /// events appear to have been swapped in time.
+    ///
+    /// NOTE: The above is the original comment from the Java implementation. The
+    /// "base 0" is referring to the fact that the returned Id is not including the
+    /// FIRST_PERSON_ID offset, and should really be "offset 0".
+    pub fn next_base0_person_id(&mut self, conf: &config::Config, event_id: Id) -> Id {
+        let num_people = self.last_base0_person_id(conf, event_id) + 1;
+        let active_people = std::cmp::min(num_people, config::NUM_ACTIVE_PEOPLE);
+        let n = self
+            .rng
+            .gen_range(0..(active_people + config::PERSON_ID_LEAD));
+        num_people - active_people + n
     }
-    // About to generate a person.
-    epoch * conf.person_proportion + offset
-}
 
-// Return a random US state.
-fn next_us_state<R: Rng + ?Sized>(rng: &mut R) -> String {
-    US_STATES.choose(rng).unwrap().to_string()
-}
+    /// Return the last valid person id (ignoring FIRST_PERSON_ID). Will be the
+    /// current person id if due to generate a person.
+    pub fn last_base0_person_id(&self, conf: &config::Config, event_id: Id) -> Id {
+        let epoch = event_id / conf.total_proportion();
+        let mut offset = event_id % conf.total_proportion();
 
-// Return a random US city.
-fn next_us_city<R: Rng + ?Sized>(rng: &mut R) -> String {
-    US_CITIES.choose(rng).unwrap().to_string()
-}
+        if offset >= conf.person_proportion {
+            // About to generate an auction or bid.
+            // Go back to the last person generated in this epoch.
+            offset = conf.person_proportion - 1;
+        }
+        // About to generate a person.
+        epoch * conf.person_proportion + offset
+    }
 
-// Return a random person name.
-fn next_person_name<R: Rng + ?Sized>(rng: &mut R) -> String {
-    format!(
-        "{} {}",
-        FIRST_NAMES.choose(rng).unwrap(),
-        LAST_NAMES.choose(rng).unwrap()
-    )
-}
+    // Return a random US state.
+    fn next_us_state(&mut self) -> String {
+        US_STATES.choose(&mut self.rng).unwrap().to_string()
+    }
 
-// Return a random email address.
-fn next_email<R: Rng + ?Sized>(rng: &mut R) -> String {
-    format!("{}@{}.com", next_string(rng, 7), next_string(rng, 5))
-}
+    // Return a random US city.
+    fn next_us_city(&mut self) -> String {
+        US_CITIES.choose(&mut self.rng).unwrap().to_string()
+    }
 
-// Return a random credit card number.
-fn next_credit_card<R: Rng + ?Sized>(rng: &mut R) -> String {
-    format!(
-        "{:04} {:04} {:04} {:04}",
-        rng.gen_range(0..10_000),
-        rng.gen_range(0..10_000),
-        rng.gen_range(0..10_000),
-        rng.gen_range(0..10_000)
-    )
+    // Return a random person name.
+    fn next_person_name(&mut self) -> String {
+        format!(
+            "{} {}",
+            FIRST_NAMES.choose(&mut self.rng).unwrap(),
+            LAST_NAMES.choose(&mut self.rng).unwrap()
+        )
+    }
+
+    // Return a random email address.
+    fn next_email(&mut self) -> String {
+        format!("{}@{}.com", self.next_string(7), self.next_string(5))
+    }
+
+    // Return a random credit card number.
+    fn next_credit_card(&mut self) -> String {
+        format!(
+            "{:04} {:04} {:04} {:04}",
+            &mut self.rng.gen_range(0..10_000),
+            &mut self.rng.gen_range(0..10_000),
+            &mut self.rng.gen_range(0..10_000),
+            &mut self.rng.gen_range(0..10_000)
+        )
+    }
 }
 
 #[cfg(test)]
@@ -147,10 +147,11 @@ mod tests {
     #[test]
     fn test_next_person() {
         let conf = make_default_config();
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let mut rng = StepRng::new(0, 5);
-
-        let p = next_person(&conf, 105, &mut rng, 1_000_000_000_000);
+        let p = ng.next_person(&conf, 105, 1_000_000_000_000);
 
         assert_eq!(
             p,
@@ -171,46 +172,52 @@ mod tests {
     #[test]
     fn test_next_base0_person_id() {
         let conf = make_default_config();
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
         // When one more than the last person id is less than the configured
         // active people (1000), the id returned is a random id from one of
         // the currently active people plus the 'lead' people.
         // Note: the mock rng is always returning zero for the random addition
         // in the range (0..active_people).
-        assert_eq!(next_base0_person_id(&conf, 50 * 998, &mut rng), 0);
+        assert_eq!(ng.next_base0_person_id(&conf, 50 * 998), 0);
 
         // Even when one more than the last person id is equal to the configured
         // active people, the id returned is a random id from one of the
         // active people plus the 'lead' people.
-        assert_eq!(next_base0_person_id(&conf, 50 * 999, &mut rng), 0);
+        assert_eq!(ng.next_base0_person_id(&conf, 50 * 999), 0);
 
         // When one more than the last person id is one greater than the
         // configured active people, we consider the most recent
         // NUM_ACTIVE_PEOPLE to be the active ones, and return a random id from
         // those plus the 'lead'people.
-        assert_eq!(next_base0_person_id(&conf, 50 * 1000, &mut rng), 1);
+        assert_eq!(ng.next_base0_person_id(&conf, 50 * 1000), 1);
 
         // When one more than the last person id is 501 greater than the
         // configured active people, we consider the most recent
         // NUM_ACTIVE_PEOPLE to be the active ones, and return a random id from
         // those plus the 'lead' people.
-        assert_eq!(next_base0_person_id(&conf, 50 * 1500, &mut rng), 501);
+        assert_eq!(ng.next_base0_person_id(&conf, 50 * 1500), 501);
     }
 
     #[test]
     fn test_last_base0_person_id_default() {
         let conf = make_default_config();
+        let ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
+
         // With the default config, the first 50 events will only include one
         // person
-        assert_eq!(last_base0_person_id(&conf, 25), 0);
+        assert_eq!(ng.last_base0_person_id(&conf, 25), 0);
 
         // The 50th event will correspond to the next...
-        assert_eq!(last_base0_person_id(&conf, 50), 1);
-        assert_eq!(last_base0_person_id(&conf, 75), 1);
+        assert_eq!(ng.last_base0_person_id(&conf, 50), 1);
+        assert_eq!(ng.last_base0_person_id(&conf, 75), 1);
 
         // And so on...
-        assert_eq!(last_base0_person_id(&conf, 100), 2);
+        assert_eq!(ng.last_base0_person_id(&conf, 100), 2);
     }
 
     #[test]
@@ -220,56 +227,69 @@ mod tests {
         // proportion, makes the total 25.
         let mut conf = make_default_config();
         conf.bid_proportion = 21;
+        let ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
         // With the total proportion at 25, there will be a new person
         // at every 25th event.
-        assert_eq!(last_base0_person_id(&conf, 25), 1);
-        assert_eq!(last_base0_person_id(&conf, 50), 2);
-        assert_eq!(last_base0_person_id(&conf, 75), 3);
-        assert_eq!(last_base0_person_id(&conf, 100), 4);
+        assert_eq!(ng.last_base0_person_id(&conf, 25), 1);
+        assert_eq!(ng.last_base0_person_id(&conf, 50), 2);
+        assert_eq!(ng.last_base0_person_id(&conf, 75), 3);
+        assert_eq!(ng.last_base0_person_id(&conf, 100), 4);
     }
 
     #[test]
     fn test_next_us_state() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let s = next_us_state(&mut rng);
+        let s = ng.next_us_state();
 
         assert_eq!(s, "AZ");
     }
 
     #[test]
     fn test_next_us_city() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let c = next_us_city(&mut rng);
+        let c = ng.next_us_city();
 
         assert_eq!(c, "Phoenix");
     }
 
     #[test]
     fn test_next_person_name() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let n = next_person_name(&mut rng);
+        let n = ng.next_person_name();
 
         assert_eq!(n, "Peter Shultz");
     }
 
     #[test]
     fn test_next_email() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let e = next_email(&mut rng);
+        let e = ng.next_email();
 
         assert_eq!(e, "AAA@AAA.com");
     }
 
     #[test]
     fn test_next_credit_card() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let e = next_credit_card(&mut rng);
+        let e = ng.next_credit_card();
 
         assert_eq!(e, "0000 0000 0000 0000");
     }

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -21,12 +21,15 @@ impl<R: Rng + ?Sized> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Config;
+    use clap::Parser;
     use rand::rngs::mock::StepRng;
 
     #[test]
     fn next_string_length() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
+            config: Config::parse(),
         };
 
         let s = ng.next_string(5);

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -7,7 +7,7 @@ use rand::{distributions::Alphanumeric, Rng};
 
 const MIN_STRING_LENGTH: usize = 3;
 
-impl<R: Rng + ?Sized> NexmarkGenerator<R> {
+impl<R: Rng> NexmarkGenerator<R> {
     pub fn next_string(&mut self, max_length: usize) -> String {
         let len = self.rng.gen_range(MIN_STRING_LENGTH..=max_length);
         (&mut self.rng)

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -2,17 +2,20 @@
 //!
 //! API based on the equivalent [Nexmark Flink StringsGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/StringsGenerator.java).
 
+use super::NexmarkGenerator;
 use rand::{distributions::Alphanumeric, Rng};
 
 const MIN_STRING_LENGTH: usize = 3;
 
-/// Returns a string of random alphanumeric characters.
-pub fn next_string<R: Rng + ?Sized>(rng: &mut R, max_length: usize) -> String {
-    let len = rng.gen_range(MIN_STRING_LENGTH..=max_length);
-    rng.sample_iter(&Alphanumeric)
-        .take(len)
-        .map(char::from)
-        .collect()
+impl<R: Rng + ?Sized> NexmarkGenerator<R> {
+    pub fn next_string(&mut self, max_length: usize) -> String {
+        let len = self.rng.gen_range(MIN_STRING_LENGTH..=max_length);
+        (&mut self.rng)
+            .sample_iter(&Alphanumeric)
+            .take(len)
+            .map(char::from)
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -22,9 +25,11 @@ mod tests {
 
     #[test]
     fn next_string_length() {
-        let mut rng = StepRng::new(0, 5);
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+        };
 
-        let s = next_string(&mut rng, 5);
+        let s = ng.next_string(5);
 
         assert_eq!(s, "AAA");
     }


### PR DESCRIPTION
Hi @Kixiron . This is what I think you were describing in https://github.com/vmware/database-stream-processor/pull/101#discussion_r914232253 ?

It adds a `NexmarkGenerator` struct which holds both the `Rng` and the `Config`, so that all the functions no longer need those in their signatures as they're bound to the instance.

I'm still not convinced that it's worth moving from the API defined in the Java Nexmark implementation in this way (and move away from purely functional to maintaining state), but if you think it's worthwhile / important, happy to go with that.

Note that it means we have to use `&mut self` for many of the functions (since the `Rng` needs to be passed as `&mut`).

Anyway, let me know what you think/prefer.